### PR TITLE
Update README Syntax Highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const Component = ReactionsComponent;
 
 Let's say you want some async data but don't want to make a whole new component just for the lifecycles to get it:
 
-```render-babel
+```jsx
 // import Component from '@reactions/component'
 const Component = ReactComponentComponent;
 
@@ -80,7 +80,7 @@ ReactDOM.render(
 Or maybe you need a little bit of state but an entire component
 seems a bit heavy:
 
-```render-babel
+```jsx
 // import Component from '@reactions/component'
 const Component = ReactComponentComponent;
 


### PR DESCRIPTION
I like pretty colors and the `render-babel` syntax highlighting was not working for me (chrome, linux) on Github. `jsx` seems to work however on both github and npm

Example on [github](https://github.com/mui-org/material-ui/blob/master/README.md#usage) and [npm](https://www.npmjs.com/package/material-ui#usage)